### PR TITLE
Add foldxl, foldxt and foldxd

### DIFF
--- a/docs/src/reference/manual.md
+++ b/docs/src/reference/manual.md
@@ -31,6 +31,9 @@ Channel
 ### Experimental transducible processes
 
 ```@docs
+foldxl
+foldxt
+foldxd
 Transducers.channel_unordered
 Transducers.append_unordered!
 ```

--- a/src/Transducers.jl
+++ b/src/Transducers.jl
@@ -50,6 +50,9 @@ export AdHocFoldable,
     dreduce,
     dtransduce,
     eduction,
+    foldxd,
+    foldxl,
+    foldxt,
     ifunreduced,
     opcompose,
     push!!,
@@ -139,6 +142,7 @@ include("simd.jl")
 include("processes.jl")
 include("reduce.jl")
 include("dreduce.jl")
+include("folds.jl")
 include("unordered.jl")
 include("air.jl")
 include("lister.jl")

--- a/src/folds.jl
+++ b/src/folds.jl
@@ -1,0 +1,98 @@
+"""
+    foldxl(rf, [xf,] itr)
+    foldxl(rf) -> itr -> foldxl(rf, itr)
+
+e**X**tended **l**eft fold.  Like `foldl`, but always uses the
+extended protocol defined in Transducers.jl.
+
+$_experimental_warning
+
+# Examples
+```jldoctest
+julia> using Transducers
+
+julia> foldxl(+, 1:5 |> Filter(isodd))
+9
+
+julia> 1:5 |> Filter(isodd) |> foldxl(+)
+9
+```
+
+Since [`TeeRF`](@ref) requires the extended fold protocol,
+`foldl(TeeRF(min, max), [5, 2, 6, 8, 3])` does not work while it works
+with `foldxl`:
+
+```jldoctest; setup = :(using Transducers)
+julia> foldxl(TeeRF(min, max), [5, 2, 6, 8, 3])
+(2, 8)
+```
+
+The unary method of `foldlx` is useful when combined with `|>`:
+
+```jldoctest; setup = :(using Transducers)
+julia> (1:5, 4:-1:1) |> Cat() |> Filter(isodd) |> Enumerate() |> foldxl() do a, b
+           a[2] < b[2] ? b : a
+       end
+(3, 5)
+```
+"""
+foldxl
+foldxl(rf; kw...) = itr -> foldxl(rf, itr; kw...)
+foldxl(rf, itr; kw...) = foldl(rf, extract_transducer(itr)...; kw...)
+foldxl(rf, xf, itr; kw...) = foldl(rf, xf, itr; kw...)
+
+"""
+    foldxt(rf, [xf,] itr)
+    foldxt(rf) -> itr -> foldxt(rf, itr)
+
+e**X**tended **t**hreaded fold (reduce).  This is a multi-threaded
+`reduce` based on extended fold protocol defined in Transducers.jl.
+
+$_experimental_warning
+
+# Examples
+```jldoctest
+julia> using Transducers
+
+julia> foldxt(+, 1:5 |> Filter(isodd))
+9
+
+julia> 1:5 |> Filter(isodd) |> foldxt(+)
+9
+
+julia> foldxt(TeeRF(min, max), [5, 2, 6, 8, 3])
+(2, 8)
+```
+"""
+foldxt
+foldxt(rf; kw...) = itr -> foldxt(rf, itr; kw...)
+foldxt(rf, itr; kw...) = reduce(rf, extract_transducer(itr)...; kw...)
+foldxt(rf, xf, itr; kw...) = reduce(rf, xf, itr; kw...)
+
+"""
+    foldxd(rf, [xf,] itr)
+    foldxd(rf) -> itr -> foldxd(rf, itr)
+
+e**X**tended **d**istributed fold (reduce).  This is a distributed
+`reduce` based on extended fold protocol defined in Transducers.jl.
+
+$_experimental_warning
+
+# Examples
+```jldoctest
+julia> using Transducers
+
+julia> foldxd(+, 1:5 |> Filter(isodd))
+9
+
+julia> 1:5 |> Filter(isodd) |> foldxd(+)
+9
+
+julia> foldxd(TeeRF(min, max), [5, 2, 6, 8, 3])
+(2, 8)
+```
+"""
+foldxd
+foldxd(rf; kw...) = itr -> foldxd(rf, itr; kw...)
+foldxd(rf, itr; kw...) = dreduce(rf, extract_transducer(itr)...; kw...)
+foldxd(rf, xf, itr; kw...) = dreduce(rf, xf, itr; kw...)

--- a/test/threads/test_fold.jl
+++ b/test/threads/test_fold.jl
@@ -18,6 +18,9 @@ const parseint = Base.Fix1(parse, Int)
     reduce,
     dreduce_bs1,
     dreduce,
+    foldxl,
+    foldxt,
+    foldxd,
 ]
     @testset "no init" begin
         @test fold(+, Map(identity), 1:4) == 10
@@ -36,7 +39,7 @@ const parseint = Base.Fix1(parse, Int)
         @test fold(right, GroupBy(isodd, Map(last), +), 1:10) ==
               Dict(true => 25, false => 30)
     end
-    if fold ∉ (simple_reduce, random_reduce, dreduce_bs1, dreduce)
+    if fold ∉ (simple_reduce, random_reduce, dreduce_bs1, dreduce, foldxd)
         @testset "NoAdjoint" begin
             @test fold(
                 +,
@@ -47,7 +50,15 @@ const parseint = Base.Fix1(parse, Int)
     end
 end
 
-@testset "$fold" for fold in [foldl, simple_reduce, random_reduce, reduce_bs1, reduce]
+@testset "$fold" for fold in [
+    foldl,
+    simple_reduce,
+    random_reduce,
+    reduce_bs1,
+    reduce,
+    foldxl,
+    foldxt,
+]
     # TODO: test them with `dreduce` (don't use local functions)
     @testset "AdHocRF" begin
         averaging =
@@ -98,6 +109,13 @@ end
         @test fold(right, eduction(x for x in 1:10 if isodd(x))) == 9
         @test fold(right, Map(identity), eduction(x for x in 1:10 if isodd(x))) == 9
     end
+end
+
+@testset "$fold" for fold in [foldxl, foldxt, foldxd]
+    foldxl = foldl = nothing  # don't use
+    @test fold(TeeRF(min, max), [5, 2, 6, 8, 3]) === (2, 8)
+    @test [5, 2, 6, 8, 3] |> fold(TeeRF(min, max)) === (2, 8)
+    @test 1:5 |> Filter(isodd) |> fold(+) == 9
 end
 
 end  # module


### PR DESCRIPTION
## Commit Message
Add foldxl, foldxt and foldxd (#369)

This PR adds `foldxl`, `foldxt` and `foldxd` as the new (experimental)
entry points for calling the extended folds defined in Transducers.jl.
The plan is to deprecate `reduce` and `dreduce` in favor of `foldxt`
and `foldxd`.

* Motivation for dedicated entry points

  Often times I need to add `Map(identity)` just to dispatch to the
  fold defined in Transducers.jl (e.g,
  `foldl(TeeRF(min, max), Map(identity), xs)`).  Adding
  Transducers.jl-specific entry points like `foldxd` makes
  `Map(identity)` unnecessary.  Furthermore, decoupling entry point
  from `Base.foldl` let us have a curried version
  `itr |> xf |> foldxl(+)` which is quite useful with the new `|>`
  pattern.

* Motivation for deprecating `reduce`

  * As of #72, `sum(foldable)` calls `foldl(add_sum, foldable)` and
    not `reduce(add_sum, foldable)`.  This could be a bit surprising
    since `sum` usually calls `reduce`.

  * The `Base` implementation of `reduce` is not threaded.  So, using
    it for calling multi-threaded implementation can be confusing.
