### PR TITLE
Adjoin identity for Scan

### DIFF
--- a/src/library.jl
+++ b/src/library.jl
@@ -1184,7 +1184,7 @@ struct Scan{F, T} <: Transducer
     init::T
 end
 
-Scan(f) = Scan(f, Init)  # TODO: DefaultInit?
+Scan(f) = Scan(_asmonoid(f), Init)  # TODO: DefaultInit?
 
 isexpansive(::Scan) = false
 

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -46,6 +46,7 @@ end
     @testset for xs in iterator_variants(1:10)
         xs isa Base.Generator && continue
         @test collect(Scan(+), xs) == cumsum(xs)
+        @test collect(Scan((a, b) -> a + b), xs) == cumsum(xs)
     end
 
     xs0 = [0, -1, 3, -2, 1]


### PR DESCRIPTION
Without adjoin the identity, it's not possible to start `Scan` with a
custom reducing function.  So, when the user doesn't specify `init`,
let's assume that it's OK to automatically adjoin identity.