### PR TITLE
Make tests runnable with --depwarn=error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
   - julia -e 'using Run; Run.prepare("test/environments/main")'
 script:
-  - julia -e 'using Run; Run.test(project="test/environments/main")'
+  - julia -e 'using Run; Run.test(project="test/environments/main", depwarn=:error)'
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
   - julia -e 'using Run; Run.prepare("test/environments/main")'
 script:
-  - julia -e 'using Run; Run.test(project="test/environments/main", depwarn=:error)'
+  - julia -e 'using Run; Run.test(project="test/environments/main")'
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/test/test_examples_upgrade_to_ixf.jl
+++ b/test/test_examples_upgrade_to_ixf.jl
@@ -1,4 +1,6 @@
 module TestExamplesUpgradeToIXF
 using LiterateTest.AssertAsTest: @assert
-include("../examples/upgrade-to-ixf.jl")
+if Base.JLOptions().depwarn != 2
+    include("../examples/upgrade-to-ixf.jl")
+end
 end  # module

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -24,8 +24,8 @@ end
             [[3, 2, 1, 0], [6, 5, 4], [9, 8, 7]]
             )
         @test collect(MapCat(reverse), xs) == 0:9
-        @test collect(MapCat(reverse) |> Map(inc), xs) == 1:10
-        @test collect(MapCat(x -> reverse(x) |> Map(inc)), xs) == 1:10
+        @test xs |> MapCat(reverse) |> Map(inc) |> collect == 1:10
+        @test xs |> MapCat(x -> reverse(x) |> Map(inc)) |> collect == 1:10
     end
 end
 


### PR DESCRIPTION
This PR is tested with #381.

## Commit Message
Make tests runnable with --depwarn=error (#382)

Fix/skip tests so that it works with `--depwarn=error`.  The CI is
still run with `--depwarn=yes` to test the warning message.