### PR TITLE
Improve test_unordered.jl: Wait on explicit event

### DIFF
--- a/test/threads/test_unordered.jl
+++ b/test/threads/test_unordered.jl
@@ -56,7 +56,7 @@ end
         input = Channel(Map(identity), 1:input_length)
         trace = Channel(input_length)
         ntasks = 10
-        block = Threads.Event()
+        block = Channel{Nothing}(1)
         xs = input |> Map() do x
             put!(trace, x)
             wait(block)
@@ -69,8 +69,8 @@ end
             for _ in 1:ntasks
                 push!(traced, popfirst!(trace))
             end
-            # Now all tasks completed `put!`.
-            notify(block)
+            # Now all tasks completed `put!(trace, x)`.
+            put!(block, nothing)
             for x in trace
                 push!(traced, x)
             end
@@ -86,7 +86,7 @@ end
         input = Channel(Map(identity), 1:input_length)
         trace = Channel(input_length)
         ntasks = 10
-        block = Threads.Event()
+        block = Channel{Nothing}(1)
         xs = input |> Map() do x
             put!(trace, x)
             wait(block)
@@ -103,8 +103,8 @@ end
             for _ in 1:ntasks
                 push!(traced, popfirst!(trace))
             end
-            # Now all tasks completed `put!`.
-            notify(block)
+            # Now all tasks completed `put!(trace, x)`.
+            put!(block, nothing)
             for x in trace
                 push!(traced, x)
             end

--- a/test/threads/test_unordered.jl
+++ b/test/threads/test_unordered.jl
@@ -56,21 +56,29 @@ end
         input = Channel(Map(identity), 1:input_length)
         trace = Channel(input_length)
         ntasks = 10
+        block = Threads.Event()
         xs = input |> Map() do x
             put!(trace, x)
-
-            # Try to make sure all tasks hits above line.  This may
-            # not be required since `put!` would invoke task switch.
-            # But let's play on the safe side:
-            sleep(0.1)
-
+            wait(block)
             x
         end |> Map() do x
             error("Throwing error with x = $x")
         end
+        bg = @async begin
+            traced = Int[]
+            for _ in 1:ntasks
+                push!(traced, popfirst!(trace))
+            end
+            # Now all tasks completed `put!`.
+            notify(block)
+            for x in trace
+                push!(traced, x)
+            end
+            traced
+        end
         @test_throws Exception take!(channel_unordered(xs; ntasks=ntasks))
         close(trace)
-        consumed = sort!(collect(trace))
+        consumed = sort!(fetch(bg))
         @test consumed == 1:ntasks
     end
     @testset "error handling (terminate other tasks)" begin
@@ -78,21 +86,34 @@ end
         input = Channel(Map(identity), 1:input_length)
         trace = Channel(input_length)
         ntasks = 10
+        block = Threads.Event()
         xs = input |> Map() do x
             put!(trace, x)
-            sleep(0.01)
+            wait(block)
             x
         end |> Map() do x
             if x == 1
-                sleep(0.02)
                 error("Throwing error with x = $x")
             end
+            sleep(0.01)
             x
+        end
+        bg = @async begin
+            traced = Int[]
+            for _ in 1:ntasks
+                push!(traced, popfirst!(trace))
+            end
+            # Now all tasks completed `put!`.
+            notify(block)
+            for x in trace
+                push!(traced, x)
+            end
+            traced
         end
         @test_throws Exception collect(channel_unordered(xs; ntasks=ntasks))
         close(trace)
-        consumed = sort!(collect(trace))
-        @test length(consumed) > ntasks
+        consumed = sort!(fetch(bg))
+        @test length(consumed) >= ntasks
         @test length(consumed) < input_length
     end
 end


### PR DESCRIPTION
## Commit Message
Improve test_unordered.jl: Wait on explicit event (#392)

Trying to address #216 by changing the check from `length(consumed) >
ntasks` to `length(consumed) >= ntasks`.

At the same time, switching to `Event`-based setup rather than the
fragile `sleep`-based setup (though the tests are in theory still a
bit non-deterministic...).  Hopefully this makes the test more robust.