### PR TITLE
Suppress replacing docs warning

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -114,7 +114,7 @@ Multi-threaded reduce.
 !!! warning
     `reduce` is a deprecated. Use [`foldxt`](@ref) instead.
 """
-reduce
+reduce(rf, xf::Transducer, itr)
 
 @deprecate dreduce(rf, xf, itr; kw...) foldxd(rf, xf, itr; kw...)
 @deprecate dreduce(rf, itr; kw...) foldxd(rf, itr; kw...)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -114,7 +114,7 @@ Multi-threaded reduce.
 !!! warning
     `reduce` is a deprecated. Use [`foldxt`](@ref) instead.
 """
-reduce(rf, xf::Transducer, itr)
+reduce
 
 @deprecate dreduce(rf, xf, itr; kw...) foldxd(rf, xf, itr; kw...)
 @deprecate dreduce(rf, itr; kw...) foldxd(rf, itr; kw...)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -112,7 +112,7 @@ using Base: reduce
 Multi-threaded reduce.
 
 !!! warning
-    `reduce` is a deprecated. Use [`foldxt`](@ref) instead.
+    `reduce` is deprecated. Use [`foldxt`](@ref) instead.
 """
 reduce
 
@@ -125,6 +125,6 @@ reduce
 Distributed reduce.
 
 !!! warning
-    `dreduce` is a deprecated. Use [`foldxd`](@ref) instead.
+    `dreduce` is deprecated. Use [`foldxd`](@ref) instead.
 """
 dreduce

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -62,13 +62,6 @@ julia> foldxt(TeeRF(min, max), [5, 2, 6, 8, 3])
 """
 foldxt
 
-"""
-    reduce(step, xf, reducible)
-
-`reduce(step, xf, reducible)` is a deprecated alias of [`foldxt`](@ref).
-"""
-Base.reduce
-
 const _MAPREDUCE_DEPWARN = (
     "`mapreduce(::Transducer, rf, itr)` is deprecated. " *
     " Use `foldxt(rf, ::Transducer, itr)` if you do not need to call single-argument" *


### PR DESCRIPTION
## Commit Message
Suppress replacing docs warning (#394)

This patch fixes the following warning

    Warning: Replacing docs for `Base.reduce :: Union{}` in module `Transducers`