### PR TITLE
Add a specialized fold for CartesianIndices

### DIFF
--- a/src/processes.jl
+++ b/src/processes.jl
@@ -263,6 +263,13 @@ end
     )
 end
 
+@inline function __foldl__(rf0, init, cartesian::CartesianIndices)
+    rf = Map(CartesianIndex)'(rf0)
+    val = _foldl_product(rf, init, (), cartesian.indices...)
+    val isa Reduced && return val
+    return complete(rf, val)
+end
+
 @inline function __foldl__(
         rf, init,
         prod::Iterators.ProductIterator{<:Tuple{Any,Any,Vararg{Any}}})

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -7,6 +7,10 @@ The reducible can support it using `@simd_if`.
 struct UseSIMD{ivdep} <: Transducer end
 next(rf::R_{UseSIMD}, result, input) = next(inner(rf), result, input)
 
+# Keep `UseSIMD` as the outer-most transducer when appropriate:
+reducingfunction(xf::Transducer, step::R_{UseSIMD}) =
+    usesimd(Reduction(xf, inner(step)), xform(step))
+
 # Make sure UseSIMD is the outer-most transducer when UseSIMD is used
 # via Cat.
 skipcomplete(rf::R_{UseSIMD}) =

--- a/test/test_processes.jl
+++ b/test/test_processes.jl
@@ -60,6 +60,16 @@ include("preamble.jl")
         end
     end
 
+    @testset "CartesianIndices" begin
+        @testset for cartesian in [
+            CartesianIndices((1:2,)),
+            CartesianIndices((1:2, 3:5)),
+            CartesianIndices((1:2, 3:5, 6:9)),
+        ]
+            @test collect(Map(identity), cartesian) == vec(cartesian)
+        end
+    end
+
     @testset "product-of-iterators" begin
         iterator_prototypes = [
             (1, 2),

--- a/test/test_simd.jl
+++ b/test/test_simd.jl
@@ -30,6 +30,22 @@ asrf(xfs...) = asrf(opcompose(xfs...))
           asrf(Map(sin), Cat(), Map(cos), Cat(), xfsimd, Map(tan))
 end
 
+@testset "reducingfunction" begin
+    @test opcompose(UseSIMD{false}(), Map(sin), Map(cos))'(+) ===
+        Map(sin)'(Map(cos)'(+; simd = true))
+    @test opcompose(MapCat(collect), UseSIMD{false}(), Map(cos))'(+) ===
+        MapCat(collect)'(Map(cos)'(+; simd = true))
+    @testset for (f, g) in [
+        (Map(sin), Map(cos)),
+        (MapCat(collect), Map(cos)),
+        (MapCat(collect), opcompose(MapCat(collect), Map(cos))),
+        (opcompose(MapCat(collect), MapCat(collect)), Map(cos)),
+    ]
+        @test f'(g'(+; simd = true)) === f'(g'(+); simd = true)
+        @test f'(g'(+; simd = true)) === opcompose(f, g)'(+; simd = true)
+    end
+end
+
 @testset "skipcomplete" begin
     @testset for rf in [
             asrf(UseSIMD{false}()),


### PR DESCRIPTION
## Commit Message
Add a specialized fold for CartesianIndices (#400)

The implementation of `foldl` for `CartesianIndices` because I can
just redirect this to the one for `Iterators.product` (i.e.,
`_foldl_product`).  Most of the changes are for making sure that the
re-transformation `rf = Map(CartesianIndex)'(rf0)` preserves the
correct SIMD flag.