### PR TITLE
Specialize foldl for cartesian style arrays

### DIFF
--- a/src/basics.jl
+++ b/src/basics.jl
@@ -118,3 +118,8 @@ end
 # index style:
 @inline _firstindex(bc::Broadcasted) = first((axes(bc)::Tuple{Any})[1])
 @inline _lastindex(bc::Broadcasted) = last((axes(bc)::Tuple{Any})[1])
+
+@inline _CartesianIndices(arr) = CartesianIndices(arr)
+
+# `eachindex` on `Broadcasted` hopefully returns an `CartesianIndices`:
+@inline _CartesianIndices(bc::Broadcasted) = eachindex(bc)::CartesianIndices

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -119,7 +119,12 @@ end
 @inline _firstindex(bc::Broadcasted) = first((axes(bc)::Tuple{Any})[1])
 @inline _lastindex(bc::Broadcasted) = last((axes(bc)::Tuple{Any})[1])
 
+# Define `CartesianIndices` for `Broadcasted`
 @inline _CartesianIndices(arr) = CartesianIndices(arr)
+@inline _CartesianIndices(bc::Broadcasted) = CartesianIndices(axes(bc)::Tuple)
 
-# `eachindex` on `Broadcasted` hopefully returns an `CartesianIndices`:
-@inline _CartesianIndices(bc::Broadcasted) = eachindex(bc)::CartesianIndices
+# Define `IndexStyle` for `Broadcasted`
+_IndexStyle(arr) = IndexStyle(arr)
+_IndexStyle(bc::Broadcasted) = _IndexStyle(typeof(bc))
+_IndexStyle(::Type{<:Broadcasted{<:Any,<:Tuple{Any}}}) = IndexLinear()
+_IndexStyle(::Type{<:Broadcasted{<:Any}}) = IndexCartesian()

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -176,7 +176,8 @@ end
 @inline __foldl__(rf::RF, init, coll::Tuple) where {RF} =
     complete(rf, @return_if_reduced foldlargs(rf, init, coll...))
 
-@inline function __foldl__(rf::RF, init, arr::Union{AbstractArray,Broadcasted}) where {RF}
+@inline function __foldl__(rf::RF, init, arr0::Union{AbstractArray,Broadcasted}) where {RF}
+    arr = Broadcast.instantiate(arr0)
     isempty(arr) && return complete(rf, init)
     return _foldl_array(rf, init, arr, IndexStyle(arr))
 end
@@ -221,7 +222,7 @@ end
 @inline function _foldl_array(rf0::RF, init, arr, ::IndexStyle) where {RF,T}
     @inline getvalue(I) = @inbounds arr[I]
     rf = Map(getvalue)'(rf0)
-    return __foldl__(rf, init, CartesianIndices(arr))
+    return __foldl__(rf, init, _CartesianIndices(arr))
 end
 
 @inline _getvalues(i) = ()

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -179,7 +179,7 @@ end
 @inline function __foldl__(rf::RF, init, arr0::Union{AbstractArray,Broadcasted}) where {RF}
     arr = Broadcast.instantiate(arr0)
     isempty(arr) && return complete(rf, init)
-    return _foldl_array(rf, init, arr, IndexStyle(arr))
+    return _foldl_array(rf, init, arr, _IndexStyle(arr))
 end
 
 @inline function _foldl_array(rf::RF, init::T, arr, ::IndexLinear) where {RF,T}

--- a/test/test_processes.jl
+++ b/test/test_processes.jl
@@ -110,13 +110,20 @@ include("preamble.jl")
         end
     end
 
-    @testset "broadcast" begin
+    @testset "broadcast (linear)" begin
         @testset for xs in iterator_variants(1:3)
             ys = @~ xs.^2
             @test collect(Map(identity), ys) == copy(ys)
             @test foldl(+, Filter(isodd), ys) == 10
             @test foldl(+, Filter(isodd), ys; init=0) == 10
         end
+    end
+
+    @testset "broadcast (cartesian)" begin
+        xs = @~ (1:3) .+ (4:5)'
+        @test collect(Map(identity), xs) == vec(copy(xs))
+        @test foldl(+, Filter(isodd), xs) == 19
+        @test foldl(+, Filter(isodd), xs; init = 0) == 19
     end
 end
 


### PR DESCRIPTION
## Commit Message
Specialize foldl for cartesian style arrays (#407)

This patch implements a specialization of `foldl` on arrays with
`IndexCartesian` index style.  This gives us more than 2x speedup (see
`sum_transpose` benchmark).

The implementation mostly just redirects the call to `foldl` of
`CartesianIndices`.  Most of the code is for compatibility with Julia
< 1.5.  This PR also fixes a bug in `foldl` for multi-dimensional
`Broadcasted` (probably introduced by #403).