### PR TITLE
Add bench_cartesian.jl

### DIFF
--- a/benchmark/bench_cartesian.jl
+++ b/benchmark/bench_cartesian.jl
@@ -1,0 +1,41 @@
+module BenchCartesian
+
+using BenchmarkTools
+using Transducers
+
+function copyto_manual!(ys::AbstractMatrix, xs::AbstractMatrix)
+    @assert axes(ys) == axes(xs)
+    for j in 1:size(xs, 2), i in 1:size(xs, 1)
+        @inbounds ys[i, j] = xs[i, j]
+    end
+    return ys
+end
+
+function copyto_iter!(ys, xs)
+    @assert axes(ys) == axes(xs)
+    for I in CartesianIndices(xs)
+        @inbounds ys[I] = xs[I]
+    end
+    return ys
+end
+
+function copyto_xf!(ys, xs)
+    foreach(Map(identity), CartesianIndices(xs)) do I
+        @inbounds ys[I] = xs[I]
+        nothing
+    end
+    return ys
+end
+
+const SUITE = BenchmarkGroup()
+
+let xs = randn(3, 10^3)
+    ys = zero(xs)
+    s1 = SUITE["copyto!"] = BenchmarkGroup()
+    s1["man"] = @benchmarkable(copyto_manual!($ys, $xs))
+    s1["iter"] = @benchmarkable(copyto_iter!($ys, $xs))
+    s1["xf"] = @benchmarkable(copyto_xf!($ys, $xs))
+end
+
+end  # module
+BenchCartesian.SUITE


### PR DESCRIPTION
This characterizes the improvements in
6aafdde1f6ae44985e5d83dacaea203f94ddd1ab

Example minimum time:
Before (Transducers v0.4.47): 8.720 μs
After (Transducers v0.4.48-DEV): 2.628 μs
