### PR TITLE
Improve compilation latency for non-inferable case

### DIFF
--- a/src/basics.jl
+++ b/src/basics.jl
@@ -26,6 +26,9 @@ else
     _Channel(f, ::Type{T}, size; kwargs...) where {T} = Channel{T}(f, size; kwargs...)
 end
 
+_valof(::Val{x}) where {x} = x
+_valof(x) = x
+
 _typeof(::Type{T}) where {T} = Type{T}
 _typeof(::T) where {T} = T
 


### PR DESCRIPTION
The following snippets shows a big jump in the compilation latency after eb430cf76a5c25aa909858c20424aead21cfecfd (#403):

```julia
using DataFrames
using Glob
using Pkg: TOML
using Transducers

function asnamedtuple(d)
    kvs = [(Symbol(k) => v) for (k, v) in pairs(d)]
    sort!(kvs; by = first)
    return (; kvs...)
end

demo(depot_path = DEPOT_PATH) =
    depot_path |>
    MapCat() do path
        readdir(glob"registries/*/*/*/Package.toml", path)
    end |>
    Map() do path
        p = TOML.parsefile(path)
        get!(p, "subdir", nothing)
        p["datadir"] = dirname(path)
        depsfile = joinpath(p["datadir"], "Deps.toml")
        if !isfile(depsfile)
            p["deps"] = nothing
            return p
        end
        p["deps"] =
            values(TOML.parsefile(depsfile)) |>
            MapCat(pairs) |>
            MapSplat(tuple) |>
            Map(NamedTuple{(:name, :uuid)}) |>
            Set
        p
    end |>
    Map(asnamedtuple) |>
    x -> copy(DataFrame, x)

@time demo()
```

| Transducers.jl commit | w/ Julia 1.6.0-DEV.536 | w/ Julia 1.5 | w/ Julia 1.4 |
| --- | --- | --- | --- |
| 65db24b0e874a4472eb3b81543c11306c2fd8581 (pre #403) | 4.6 sec | 3.6 sec | 5.0 sec |
| eb430cf76a5c25aa909858c20424aead21cfecfd (#403) | 17 sec | 77 sec | 24 sec |
| 29d65cb43cdc1297e624c1372bbe80373d93b483 (This PR) | 8.7 sec | 27 sec | 11 sec |

## Commit Message
Improve compilation latency for non-inferable case (#412)

The tail-call pattern introduced in eb430cf76a5c25aa909858c20424aead21cfecfd
(#403) for linear indexing arrays seem to invoke a large compiler
latency (see #412 for an example).  This patch tries to mitigate the
problem by introducing a different more dynamic code path for
`__foldl__` on arrays when the reducing function is not inferrable.