### PR TITLE
Improve compilation latency by reducing recursion limit

### DIFF
--- a/src/processes.jl
+++ b/src/processes.jl
@@ -145,7 +145,7 @@ __foldl__
 # multiple locations.  This easily leads to non-concrete types in the
 # inference.
 
-const FOLDL_RECURSION_LIMIT = Val(1)
+const FOLDL_RECURSION_LIMIT = Val(2)
 # const FOLDL_RECURSION_LIMIT = nothing
 _dec(::Nothing) = nothing
 _dec(::Val{n}) where n = Val(n - 1)

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -145,7 +145,7 @@ __foldl__
 # multiple locations.  This easily leads to non-concrete types in the
 # inference.
 
-const FOLDL_RECURSION_LIMIT = Val(2)
+const FOLDL_RECURSION_LIMIT = Val(3)
 # const FOLDL_RECURSION_LIMIT = nothing
 _dec(::Nothing) = nothing
 _dec(::Val{n}) where n = Val(n - 1)

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -145,7 +145,7 @@ __foldl__
 # multiple locations.  This easily leads to non-concrete types in the
 # inference.
 
-const FOLDL_RECURSION_LIMIT = Val(0)
+const FOLDL_RECURSION_LIMIT = Val(1)
 # const FOLDL_RECURSION_LIMIT = nothing
 _dec(::Nothing) = nothing
 _dec(::Val{n}) where n = Val(n - 1)

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -145,7 +145,7 @@ __foldl__
 # multiple locations.  This easily leads to non-concrete types in the
 # inference.
 
-const FOLDL_RECURSION_LIMIT = Val(4)
+const FOLDL_RECURSION_LIMIT = Val(0)
 # const FOLDL_RECURSION_LIMIT = nothing
 _dec(::Nothing) = nothing
 _dec(::Val{n}) where n = Val(n - 1)

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -145,7 +145,7 @@ __foldl__
 # multiple locations.  This easily leads to non-concrete types in the
 # inference.
 
-const FOLDL_RECURSION_LIMIT = Val(3)
+const FOLDL_RECURSION_LIMIT = Val(4)
 # const FOLDL_RECURSION_LIMIT = nothing
 _dec(::Nothing) = nothing
 _dec(::Val{n}) where n = Val(n - 1)

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -145,7 +145,7 @@ __foldl__
 # multiple locations.  This easily leads to non-concrete types in the
 # inference.
 
-const FOLDL_RECURSION_LIMIT = Val(10)
+const FOLDL_RECURSION_LIMIT = Val(1)
 # const FOLDL_RECURSION_LIMIT = nothing
 _dec(::Nothing) = nothing
 _dec(::Val{n}) where n = Val(n - 1)


### PR DESCRIPTION
An alternative fix to #412.

Compilation benchmark using the example in #412:

| `FOLDL_RECURSION_LIMIT` | w/ Julia 1.6.0-DEV.536 | w/ Julia 1.5 | w/ Julia 1.4 |
| --- | --- | --- | --- |
| 0 | 5 sec | 8 sec | 6 sec |
| 1 | 6 sec | 15 sec | 8 sec |
| 2 | 7 sec | 21 sec | 10 sec |
| 3 | 8 sec | 30 sec | 12 sec |
| 4 | 9 sec | 34 sec | 14 sec |

`FOLDL_RECURSION_LIMIT = Val(0)` slows down `["teerf_filter", "noinit"]` (and speedups `["filter_sum", "1000", "RandomFloats", "noinit", "base"]`):

> | ID                                                             | time ratio                   | memory ratio    |
> |----------------------------------------------------------------|------------------------------|-----------------|
> | `["filter_sum", "1000", "RandomFloats", "noinit", "base"]`     | 0.31 (5%) :white_check_mark: |      1.00 (1%)  |
> | `["teerf_filter", "noinit"]`                                   |              226.80 (5%) :x: | 832.57 (1%) :x: |
>
> --- https://github.com/JuliaFolds/Transducers-data/blob/benchmark-results/2020/08/10/070744/result.md

Interestingly, `FOLDL_RECURSION_LIMIT = Val(1)` improves the performance:

> | ID                                                             | time ratio                   | memory ratio |
> |----------------------------------------------------------------|------------------------------|--------------|
> | `["filter_sum", "1000", "RandomFloats", "noinit", "base"]`     | 0.26 (5%) :white_check_mark: |   1.00 (1%)  |
>
> --- https://github.com/JuliaFolds/Transducers-data/blob/benchmark-results/2020/08/10/064257/result.md


Re: `["filter_sum", "1000", "RandomFloats", "noinit", "base"]`, see #403.

## Commit Message
Improve compilation latency by reducing recursion limit (#412)

The tail-call pattern introduced in eb430cf76a5c25aa909858c20424aead21cfecfd
(#403) for linear indexing arrays seem to invoke a large compiler
latency (see #412 for an example). This patch tries to mitigate the
problem by reducing the `FOLDL_RECURSION_LIMIT` to 1.  This still
allows *two* recursive calls.  All the benchmarks do not show
noticeable degradation (presumably because recursion deeper than this
is not exercised in the benchmarks).  Note that setting it to 0 (one
recursive call) shows 2x slowdown in `["teerf_filter", "noinit"]`
benchmark.