### PR TITLE
Workaround over-sensitive ambiguity detection from JuliaLang/julia#36962

### DIFF
--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -1,10 +1,10 @@
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "2c366fa12569d9232b5b7cfa37c36f3f1b2665b2"
+git-tree-sha1 = "0ce3be2271a966746ea05caf493edf45162cce1b"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.4-DEV"
+version = "0.4.5-DEV"
 
 [[ArgCheck]]
 git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -2,11 +2,11 @@
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "2c366fa12569d9232b5b7cfa37c36f3f1b2665b2"
+git-tree-sha1 = "0ce3be2271a966746ea05caf493edf45162cce1b"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.4-DEV"
+version = "0.4.5-DEV"
 
 [[ArgCheck]]
 git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -12,8 +12,14 @@ using Transducers
 # )
 
 @testset "Method ambiguity" begin
+    if VERSION >= v"1.6.0-DEV.816"
+        @warn "Ignoring ambiguities from `Base` to workaround JuliaLang/julia#36962"
+        packages = [Transducers]
+    else
+        packages = [Transducers, Base]
+    end
     Aqua.test_ambiguities(
-        [Transducers, Base],
+        packages,
         exclude = [Base.get, Setfield.set, Setfield.modify, map!],
     )
 end


### PR DESCRIPTION
## Commit Message
Workaround over-sensitive ambiguity detection from JuliaLang/julia#36962 (#419)

* Update to https://github.com/JuliaTesting/Aqua.jl/pull/32
* Don't call test_ambiguities with Base in julia >= 1.6.0-DEV.816