### PR TITLE
Update to MacroTools 0.5.6

### DIFF
--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -215,10 +215,10 @@ uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 version = "0.5.1"
 
 [[MacroTools]]
-deps = ["DataStructures", "Markdown", "Random"]
-git-tree-sha1 = "07ee65e03e28ca88bc9a338a3726ae0c3efaa94b"
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.4"
+version = "0.5.6"
 
 [[Markdown]]
 deps = ["Base64"]


### PR DESCRIPTION
This is required for running test with Julia 1.6-DEV.