### PR TITLE
Move executors from FLoops to Transducers

### DIFF
--- a/docs/src/reference/manual.md
+++ b/docs/src/reference/manual.md
@@ -79,6 +79,14 @@ unreduced
 ifunreduced
 ```
 
+## Executors
+
+```@docs
+SequentialEx
+ThreadedEx
+DistributedEx
+```
+
 ## Miscellaneous
 
 ```@docs

--- a/src/Transducers.jl
+++ b/src/Transducers.jl
@@ -7,6 +7,7 @@ export AdHocFoldable,
     CopyInit,
     Count,
     Dedupe,
+    DistributedEx,
     Drop,
     DropLast,
     DropWhile,
@@ -34,12 +35,14 @@ export AdHocFoldable,
     Replace,
     Scan,
     ScanEmit,
+    SequentialEx,
     TCat,
     Take,
     TakeLast,
     TakeNth,
     TakeWhile,
     TeeRF,
+    ThreadedEx,
     Transducer,
     Unique,
     Zip,
@@ -141,6 +144,7 @@ include("groupby.jl")
 include("broadcasting.jl")
 include("combinators.jl")
 include("simd.jl")
+include("executors.jl")
 include("processes.jl")
 include("reduce.jl")
 include("nondeterministic_threading.jl")

--- a/src/executors.jl
+++ b/src/executors.jl
@@ -1,0 +1,69 @@
+abstract type Executor end
+struct SequentialEx{K} <: Executor
+    kwargs::K
+end
+struct ThreadedEx{K} <: Executor
+    kwargs::K
+end
+struct DistributedEx{K} <: Executor
+    kwargs::K
+end
+
+"""
+    SequentialEx(; kwargs...)
+    ThreadedEx(; kwargs...)
+    DistributedEx(; kwargs...)
+
+Sequential, threaded, and distributed executor.  An executor specifies
+execution strategy and its parameters.
+
+See [`foldxl`](@ref), [`foldxt`](@ref) and [`foldxd`](@ref) for usable
+keyword arguments.
+"""
+(SequentialEx, ThreadedEx, DistributedEx)
+
+maybe_set_simd(exc::Executor, simd) =
+    isdefined(exc.kwargs, :simd) ? exc : @set exc.kwargs = merge(exc.kwargs, (simd = simd,))
+
+(::Type{Ex})(; kwargs...) where {Ex<:Executor} = Ex(kwargs.data)
+
+transduce(xf, rf::RF, init, coll, exc::SequentialEx) where {RF} =
+    transduce(xf, rf, init, coll; exc.kwargs...)
+transduce(xf, rf, init, coll, exc::ThreadedEx) =
+    transduce_assoc(xf, rf, init, coll; exc.kwargs...)
+transduce(xf, rf, init, coll, exc::DistributedEx) =
+    dtransduce(xf, rf, init, coll; exc.kwargs...)
+
+fold(rf::RF, coll, exec::Executor; init = DefaultInit) where {RF} =
+    transduce(IdentityTransducer(), rf, init, coll, exec)
+
+function fold(rf::RF, coll; init = DefaultInit, kwargs...) where {RF}
+    xf, coll0 = extract_transducer(coll)
+    return unreduced(
+        transduce(xf, Completing(rf), init, coll0, executor_for(coll0; kwargs...)),
+    )
+end
+
+fold(rf; kw...) = itr -> fold(rf, itr; kw...)
+
+executor_for(::Any; kwargs...) = SequentialEx(; kwargs...)
+
+function Base.show(io::IO, exc::Executor)
+    T = typeof(exc.kwargs)
+    if (
+        fieldtype(typeof(exc), 1) !== typeof(exc.kwargs) ||
+        any(i -> typeof(exc.kwargs[i]) != fieldtype(T, i), 1:nfields(exc.kwargs))
+    )
+        return invoke(show, Tuple{IO,Any}, io, exc)
+    end
+    Ex = getfield(parentmodule(typeof(exc)), nameof(typeof(exc)))
+    print(io, Ex)
+    if isempty(exc.kwargs)
+        print(io, "()")
+    elseif length(exc.kwargs) == 1
+        print(io, '(', fieldname(T, 1), " = ", exc.kwargs[1], ')')
+    else
+        print(io, exc.kwargs)
+    end
+    return
+end

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -361,7 +361,7 @@ Call [`__foldl__`](@ref) without calling [`complete`](@ref).
     foldxl(step, reducible; init, simd) :: T
     foldl(step, xf::Transducer, reducible; init, simd) :: T
     foldl(step, ed::Eduction; init, simd) :: T
-    transduce(xf, step, init, reducible; simd) :: Union{T, Reduced{T}}
+    transduce(xf, step, init, reducible, [executor]; simd) :: Union{T, Reduced{T}}
 
 e**X**tended **l**eft fold.
 Compose transducer `xf` with reducing step function `step` and reduce
@@ -384,6 +384,7 @@ See also: [Empty result handling](@ref).
   accepts 2 arguments, wrap it with [`Completing`](@ref) to "add"
   1-argument form (i.e., [`complete`](@ref) protocol).
 - `reducible`: A reducible object (array, dictionary, any iterator, etc.).
+- `executor`: Specify an executor. See [`SequentialEx`](@ref).
 - `init`: An initial value fed to the first argument to reducing step
   function `step`.  This argument can be omitted for well know binary
   operations like `+` or `*`.  Supported binary operations are listed

--- a/test/doctests/show_exectuors.md
+++ b/test/doctests/show_exectuors.md
@@ -1,0 +1,32 @@
+# Show method for executors
+
+```@meta
+DocTestSetup = quote
+    using Transducers
+end
+```
+
+```jldoctest
+julia> SequentialEx()
+SequentialEx()
+
+julia> ThreadedEx()
+ThreadedEx()
+
+julia> DistributedEx()
+DistributedEx()
+```
+
+```jldoctest
+julia> SequentialEx(simd = true)
+SequentialEx(simd = true)
+```
+
+```jldoctest
+julia> ThreadedEx(simd = true, basesize = 1)
+ThreadedEx(simd = true, basesize = 1)
+```
+
+```@meta
+DocTestSetup = nothing
+```

--- a/test/test_executor_types.jl
+++ b/test/test_executor_types.jl
@@ -2,6 +2,7 @@ module TestExecutorTypes
 
 using Test
 using Transducers
+using Transducers: maybe_set_simd
 
 @testset "show" begin
     @test occursin("ThreadedEx()", sprint(show, ThreadedEx()))
@@ -25,6 +26,13 @@ end
         reconstructed = include_string(@__MODULE__, str)
         @test reconstructed == x
     end
+end
+
+@testset "maybe_set_simd" begin
+    @test maybe_set_simd(SequentialEx(), true).kwargs.simd === true
+    @test maybe_set_simd(SequentialEx(), false).kwargs.simd === false
+    @test maybe_set_simd(SequentialEx(simd = false), true).kwargs.simd === false
+    @test maybe_set_simd(SequentialEx(simd = true), false).kwargs.simd === true
 end
 
 end  # module

--- a/test/test_executor_types.jl
+++ b/test/test_executor_types.jl
@@ -1,0 +1,30 @@
+module TestExecutorTypes
+
+using Test
+using Transducers
+
+@testset "show" begin
+    @test occursin("ThreadedEx()", sprint(show, ThreadedEx()))
+    @test occursin("ThreadedEx(simd = true)", sprint(show, ThreadedEx(simd = true)))
+    @test occursin(
+        "ThreadedEx(simd = true, basesize = 2)",
+        sprint(show, ThreadedEx(simd = true, basesize = 2)),
+    )
+end
+
+@testset "repr" begin
+    @testset for x in [
+        ThreadedEx(),
+        ThreadedEx(simd = true),
+        ThreadedEx(simd = true, basesize = 2),
+        ThreadedEx{Any}(),
+        ThreadedEx{Any}(simd = true),
+        ThreadedEx{Any}(simd = true, basesize = 2),
+    ]
+        str = repr(x)
+        reconstructed = include_string(@__MODULE__, str)
+        @test reconstructed == x
+    end
+end
+
+end  # module

--- a/test/threads/test_fold.jl
+++ b/test/threads/test_fold.jl
@@ -126,6 +126,7 @@ end
 
 @testset "default executor" begin
     @test Transducers.fold(min, [5, 2, 6, 8, 3]) === 2
+    @test [5, 2, 6, 8, 3] |> Transducers.fold(min) === 2
 end
 
 end  # module

--- a/test/threads/test_fold.jl
+++ b/test/threads/test_fold.jl
@@ -116,4 +116,16 @@ end
     @test 1:5 |> Filter(isodd) |> fold(+) == 9
 end
 
+@testset "$ex" for ex in [SequentialEx, ThreadedEx, DistributedEx]
+    fold = Transducers.fold
+    @test transduce(Map(identity), min, Init(min), [5, 2, 6, 8, 3], ex()) === 2
+    @test transduce(Map(-), max, Init(max), [5, 2, 6, 8, 3], ex()) === -2
+    @test fold(min, [5, 2, 6, 8, 3], ex()) === 2
+    @test fold(TeeRF(min, max), [5, 2, 6, 8, 3], ex()) === (2, 8)
+end
+
+@testset "default executor" begin
+    @test Transducers.fold(min, [5, 2, 6, 8, 3]) === 2
+end
+
 end  # module


### PR DESCRIPTION
Downstreams:
- [x] https://github.com/JuliaFolds/FLoops.jl/pull/59 (https://github.com/JuliaFolds/FLoops.jl/runs/1648543273)
- [x] https://github.com/JuliaFolds/FoldsCUDA.jl/pull/35 (https://github.com/JuliaFolds/FoldsCUDA.jl/pull/35/commits/146963ab624f1fbcb1a55c65916e38276e2ef1fe)
- [x] https://github.com/JuliaFolds/data-parallelism/pull/29 (https://github.com/JuliaFolds/data-parallelism/pull/29/commits/c37cdafa0168c55d0ef9c86256e0c3600a5aa406)

## Commit Message
Move executors from FLoops to Transducers (#439)

This should go to FoldsBase (once it's created). But, until then
(= until I'm convinced that the API is OK), in Transducers.jl is a
better place to define this than FLoops.jl.