### PR TITLE
Fix tests for Julia 1.7-DEV

### DIFF
--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -30,9 +30,9 @@ version = "0.5.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "c437ba8bb82f5ec9a5d8cb881031ffa2dbe1038c"
+git-tree-sha1 = "919c7f3151e79ff196add81d7f4e45d91bbf420b"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.6.0"
+version = "3.25.0"
 
 [[CompositionsBase]]
 git-tree-sha1 = "f3955eb38944e5dd0fabf8ca1e267d94941d34a5"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -24,9 +24,9 @@ version = "0.7.7"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "b0ae6133d365da2dbc88bc43d997b1b95c9df5f6"
+git-tree-sha1 = "919c7f3151e79ff196add81d7f4e45d91bbf420b"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.9.1"
+version = "3.25.0"
 
 [[CompositionsBase]]
 git-tree-sha1 = "f3955eb38944e5dd0fabf8ca1e267d94941d34a5"

--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -40,9 +40,9 @@ version = "0.7.7"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "b0ae6133d365da2dbc88bc43d997b1b95c9df5f6"
+git-tree-sha1 = "919c7f3151e79ff196add81d7f4e45d91bbf420b"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.9.1"
+version = "3.25.0"
 
 [[CompositionsBase]]
 git-tree-sha1 = "f3955eb38944e5dd0fabf8ca1e267d94941d34a5"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -42,9 +42,9 @@ version = "0.7.7"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "b0ae6133d365da2dbc88bc43d997b1b95c9df5f6"
+git-tree-sha1 = "919c7f3151e79ff196add81d7f4e45d91bbf420b"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.9.1"
+version = "3.25.0"
 
 [[CompositionsBase]]
 git-tree-sha1 = "f3955eb38944e5dd0fabf8ca1e267d94941d34a5"

--- a/test/test_eduction.jl
+++ b/test/test_eduction.jl
@@ -12,7 +12,7 @@ using Transducers
     @test Transducer(ed3) === opcompose(Map(sin), Map(cos), Map(tan))
     @test eduction(Map(cos), eduction(Map(sin), 1:2)) ===
           eduction(opcompose(Map(sin), Map(cos)), 1:2)
-    @test eduction(sin(x) for x in 1:2) === eduction(Map(sin), 1:2)
+    @test collect(eduction(x^2 for x in 1:2)) == collect(eduction(Map(x -> x^2), 1:2))
 end
 
 end  # module

--- a/test/threads/test_copy.jl
+++ b/test/threads/test_copy.jl
@@ -2,6 +2,7 @@ module TestCopy
 
 include("../preamble.jl")
 import Tables
+using Compat: Iterators
 using DataFrames: DataFrame, eachrow
 using StructArrays: StructVector, StructArray
 using TypedTables: Table
@@ -18,11 +19,11 @@ using TypedTables: Table
             continue
         end
         @test copy(Map(identity), src) ==ₜ src
-        @test copy(eduction(identity(x) for x in src)) ==ₜ src
+        @test copy(eduction(Iterators.map(identity, src))) ==ₜ src
         if copy in (tcopy, dcopy)
             @test copy(Map(identity), src; basesize=1) ==ₜ src
-            @test copy(identity(x) for x in src) ==ₜ src
-            @test copy((identity(x) for x in src); basesize=1) ==ₜ src
+            @test copy(Iterators.map(identity, src)) ==ₜ src
+            @test copy(Iterators.map(identity, src); basesize = 1) ==ₜ src
         end
     end
     @testset "$copy(_, $T, ::$(prettytypeof(src)))" for src in Any[
@@ -32,11 +33,11 @@ using TypedTables: Table
         T in Any[DataFrame, StructArray, Table]
 
         @test copy(Map(identity), T, src) ==ₜ T(src)
-        @test copy(T, eduction(identity(x) for x in src)) ==ₜ T(src)
+        @test copy(T, eduction(Iterators.map(identity, src))) ==ₜ T(src)
         if copy in (tcopy, dcopy)
             @test copy(Map(identity), T, src; basesize = 1) ==ₜ T(src)
-            @test copy(T, identity(x) for x in src) ==ₜ T(src)
-            @test copy(T, (identity(x) for x in src); basesize = 1) ==ₜ T(src)
+            @test copy(T, Iterators.map(identity, src)) ==ₜ T(src)
+            @test copy(T, Iterators.map(identity, src); basesize = 1) ==ₜ T(src)
         end
     end
     @testset "$copy(_, eachrow(df))" begin
@@ -45,11 +46,12 @@ using TypedTables: Table
             # requires https://github.com/JuliaData/DataFrames.jl/pull/2055
             if copy in (tcopy, dcopy)
                 @test copy(Map(identity), eachrow(df); basesize=1) ==ₜ df
-                @test copy((identity(x) for x in eachrow(df)); basesize=1) ==ₜ df
-                @test copy(eduction(identity(x) for x in eachrow(df)); basesize=1) ==ₜ df
+                @test copy(Iterators.map(identity, eachrow(df)); basesize = 1) ==ₜ df
+                @test copy(eduction(Iterators.map(identity, eachrow(df))); basesize = 1) ==ₜ
+                      df
             else
                 @test copy(Map(identity), eachrow(df)) ==ₜ df
-                @test copy(eduction(identity(x) for x in eachrow(df))) ==ₜ df
+                @test copy(eduction(Iterators.map(identity, eachrow(df)))) ==ₜ df
             end
         else
             @test_broken copy(Map(identity), eachrow(df)) ==ₜ df
@@ -64,11 +66,11 @@ end
      ]
         @test collect(Map(identity), src) ==ₜ Base.collect(src)
         @test collect(IdentityTransducer(), src) ==ₜ Base.collect(src)
-        @test collect(eduction(identity(x) for x in src)) ==ₜ Base.collect(src)
+        @test collect(eduction(Iterators.map(identity, src))) ==ₜ Base.collect(src)
         if collect in (tcollect, dcollect)
             @test collect(Map(identity), src; basesize=1) ==ₜ Base.collect(src)
-            @test collect(identity(x) for x in src) ==ₜ Base.collect(src)
-            @test collect((identity(x) for x in src); basesize=1) ==ₜ Base.collect(src)
+            @test collect(Iterators.map(identity, src)) ==ₜ Base.collect(src)
+            @test collect(Iterators.map(identity, src); basesize = 1) ==ₜ Base.collect(src)
         end
     end
 end


### PR DESCRIPTION
## Commit Message
Fix tests for Julia 1.7-DEV (#445)

`(f(x) for x in xs)` is not special-cased and not lowered to
`Generator(f, xs)` anymore.  Using `Iterators.map` instead.