### PR TITLE
Calculate basesize after retransform in dtransduce

### DIFF
--- a/src/dreduce.jl
+++ b/src/dreduce.jl
@@ -58,17 +58,33 @@ foldxd(step::F, foldable; kwargs...) where {F} =
 See [`foldxd`](@ref) and [`transduce`](@ref).
 """
 function dtransduce(
-    xform::Transducer, step, init, coll;
+    xform::Transducer,
+    step,
+    init,
+    coll0;
     simd::SIMDFlag = Val(false),
-    basesize::Integer = max(1, amount(coll) ÷ Distributed.nworkers()),
-    threads_basesize::Integer = max(1, basesize ÷ Threads.nthreads()),
+    basesize::Union{Integer,Nothing} = nothing,
+    threads_basesize::Union{Integer,Nothing} = nothing,
     pool::Distributed.AbstractWorkerPool = Distributed.default_worker_pool(),
     _remote_reduce = _transduce_assoc_nocomplete,
 )
-    @argcheck basesize > 0
+    rf0 = _reducingfunction(xform, step; init = init)
+    rf1, coll = retransform(rf0, coll0)
+    rf = maybe_usesimd(rf1, simd)
     isempty(coll) && return init
     load_me_everywhere()
-    rf = _reducingfunction(xform, step; init = init, simd = simd)
+    basesize = if basesize === nothing
+        max(1, amount(coll) ÷ Distributed.nworkers())
+    else
+        Int(basesize)
+    end
+    threads_basesize = if threads_basesize === nothing
+        max(1, basesize ÷ Threads.nthreads())
+    else
+        Int(threads_basesize)
+    end
+    @argcheck basesize > 0
+    @argcheck threads_basesize > 0
     futures = map(firstindex(coll):basesize:lastindex(coll)) do start
         Distributed.remotecall(
             _remote_reduce,

--- a/test/threads/test_distributed_reduce.jl
+++ b/test/threads/test_distributed_reduce.jl
@@ -36,6 +36,11 @@ const ProgressLevel = LogLevel(-1)
     end
 end
 
+@testset "retransform" begin
+    @test foldxd(+, Map(identity), 1:9 |> Map(<=(2))) == 2
+    @test dtransduce(Map(identity), +, 0, 1:9 |> Map(<=(2))) == 2
+end
+
 @testset "dcollect & dcopy" begin
     @test dcollect(Filter(iseven), 1:10, basesize = 2) == 2:2:10
 

--- a/test/threads/test_distributed_reduce.jl
+++ b/test/threads/test_distributed_reduce.jl
@@ -37,8 +37,9 @@ const ProgressLevel = LogLevel(-1)
 end
 
 @testset "retransform" begin
-    @test foldxd(+, Map(identity), 1:9 |> Map(<=(2))) == 2
-    @test dtransduce(Map(identity), +, 0, 1:9 |> Map(<=(2))) == 2
+    square = Base.Fix2(^, 2)
+    @test foldxd(+, Map(identity), 1:9 |> Map(square)) == 285
+    @test dtransduce(Map(identity), +, 0, 1:9 |> Map(square)) == 285
 end
 
 @testset "dcollect & dcopy" begin


### PR DESCRIPTION
## Commit Message
Calculate basesize after retransform in dtransduce (#447)

This patch fixes 3-arg `foldxd` and `dtransduce` with an eduction;
e.g., `foldxd(+, Map(identity), 1:3 |> Map(<=(2)))`
