### PR TITLE
Add ReducePartitionBy

### DIFF
--- a/benchmark/multi-thread/bench_partition_length_maximum.jl
+++ b/benchmark/multi-thread/bench_partition_length_maximum.jl
@@ -1,0 +1,22 @@
+module BenchPartitionLengthMaximum
+
+using BenchmarkTools
+using Transducers
+
+const SUITE = BenchmarkGroup()
+
+f(xs, ex) = Transducers.fold(
+    max,
+    xs |> ReducePartitionBy(identity, Map(_ -> 1)'(+), 0),
+    ex;
+    init = typemin(Int),
+)
+
+let s = SUITE["rand"] = BenchmarkGroup()
+    xs = rand(Bool, 2^25)
+    s["foldl"] = @benchmarkable f($xs, SequentialEx())
+    s["reduce"] = @benchmarkable f($xs, ThreadedEx())
+end
+
+end  # module
+BenchPartitionLengthMaximum.SUITE

--- a/src/Transducers.jl
+++ b/src/Transducers.jl
@@ -33,6 +33,7 @@ export AdHocFoldable,
     PreferParallel,
     ProductRF,
     ReduceIf,
+    ReducePartitionBy,
     Reduced,
     Replace,
     Scan,
@@ -146,6 +147,7 @@ include("teezip.jl")
 include("groupby.jl")
 include("broadcasting.jl")
 include("consecutive.jl")
+include("partitionby.jl")
 include("combinators.jl")
 include("simd.jl")
 include("executors.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -703,8 +703,17 @@ next(rf::R_{MyTransducer}, result, input) =
 See [`wrap`](@ref), [`unwrap`](@ref), and [`next`](@ref).
 """
 @inline function wrapping(f, rf, result)
+    #=
     state0, iresult0 = unwrap(rf, result)
     state1, iresult1 = f(state0, iresult0)
+    =#
+    # `first`/`last` behaves nicer with type inference for `Union` of `Tuple`s:
+    a = unwrap(rf, result)
+    state0 = first(a)
+    iresult0 = last(a)
+    b = f(state0, iresult0)
+    state1 = first(b)
+    iresult1 = last(b)
     return wrap(rf, state1, iresult1)
 end
 

--- a/src/library.jl
+++ b/src/library.jl
@@ -925,11 +925,11 @@ $(_thx_clj("partition-by"))
 julia> using Transducers
 
 julia> 1:9 |> PartitionBy(x -> (x + 1) ÷ 3) |> Map(copy) |> collect
-4-element Array{Array{Int64,1},1}:
- [1]
- [2, 3, 4]
- [5, 6, 7]
- [8, 9]
+4-element Array{UnitRange{Int64},1}:
+ 1:1
+ 2:4
+ 5:7
+ 8:9
 ```
 """
 struct PartitionBy{F} <: Transducer

--- a/src/partitionby.jl
+++ b/src/partitionby.jl
@@ -1,0 +1,173 @@
+"""
+    ReducePartitionBy(f, rf, [init])
+
+Reduce partitions determined by `isequal` on the output value of `f` with an
+associative reducing function `rf`. Partitions are reduced on-the-fly and no
+intermediate arrays are allocated.
+
+# Examples
+
+Consider the input `1:6` "keyed" by a function `x -> x ÷ 3`:
+
+```jldoctest
+julia> map(x -> x ÷ 3, 1:6)
+6-element Array{Int64,1}:
+ 0
+ 0
+ 1
+ 1
+ 1
+ 2
+```
+
+i.e., there are three partitions with the key values `0`, `1`, and `2`. We
+can use `ReducePartitionBy` to compute, e.g., the length and the sum of each
+partition by:
+
+```jldoctest
+julia> using Transducers
+
+julia> 1:6 |> ReducePartitionBy(x -> x ÷ 3, Map(_ -> 1)'(+)) |> collect
+3-element Array{Int64,1}:
+ 2
+ 3
+ 1
+
+julia> 1:6 |> ReducePartitionBy(x -> x ÷ 3, +) |> collect
+3-element Array{Int64,1}:
+  3
+ 12
+  6
+```
+"""
+struct ReducePartitionBy{F,RF,Init} <: Transducer
+    f::F
+    rf::RF
+    init::Init
+end
+ReducePartitionBy(f, rf) = ReducePartitionBy(f, rf, Init)
+
+struct PartitionChunk{K,V}
+    kr::K
+    right::V
+end
+
+struct PartitionVacant{KL, KR, Left, Right}
+    kl::KL
+    kr::KR
+    left::Left
+    right::Right
+end
+
+is_prelude(::PartitionChunk) = true
+
+start(rf::R_{ReducePartitionBy}, acc) = wrap(rf, Unseen(), start(inner(rf), acc))
+
+next(rf::R_{ReducePartitionBy}, acc, input) =
+    wrapping(rf, acc) do state, iacc
+        k = xform(rf).f(input)
+        if state isa Unseen
+            init = start(xform(rf).rf, xform(rf).init)
+            (PartitionChunk(k, next(xform(rf).rf, init, input)), iacc)
+        else
+            if isequal(k, state.kr)
+                acc0 = next(xform(rf).rf, state.right, input)
+                ((@set state.right = acc0), iacc)
+            else
+                if state isa PartitionVacant
+                    y = complete(xform(rf).rf, state.right)
+                    iacc′ = next(inner(rf), iacc, y)
+                    left = state.left
+                    kl = state.kl
+                else
+                    iacc′ = iacc
+                    left = state.right
+                    kl = state.kr
+                end
+                init = start(xform(rf).rf, xform(rf).init)
+                right = next(xform(rf).rf, init, input)
+                (PartitionVacant(kl, k, left, right), iacc′)
+            end
+        end
+    end
+
+function complete(rf::R_{ReducePartitionBy}, acc)
+    state, iacc1 = unwrap(rf, acc)
+    yr = complete(xform(rf).rf, state.right)
+    iacc2 = next(inner(rf), iacc1, yr)
+    if state isa PartitionVacant
+        yl = complete(inner(rf), state.left)
+        iacc0 = next(inner(rf), start(inner(rf), DefaultInit), yl)
+        iacc3 = combine(inner(rf), iacc0, iacc2)
+    else
+        iacc3 = iacc2
+    end
+    return complete(inner(rf), iacc3)
+end
+
+function combine(rf::R_{ReducePartitionBy}, a, b)
+    a1, a2 = unwrap(rf, a)
+    b1, b2 = unwrap(rf, b)
+    # @show a1 b1
+    if a1 isa PartitionChunk
+        if b1 isa PartitionChunk
+            if isequal(a1.kr, b1.kr)
+                c1 = PartitionChunk(a1.kr, combine(xform(rf).rf, a1.right, b1.right))
+            else
+                c1 = PartitionVacant(a1.kr, b1.kr, a1.right, b1.right)
+            end
+        else
+            if isequal(a1.kr, b1.kl)
+                c1 = PartitionVacant(a1.kr, b1.kr, combine(xform(rf).rf, a1.right, b1.left), b1.right)
+            else
+                y = complete(xform(rf).rf, b1.left)
+                # @show y
+                a2 = next(inner(rf), a2, y)
+                c1 = PartitionVacant(a1.kr, b1.kr, a1.right, b1.right)
+            end
+        end
+    else
+        if b1 isa PartitionChunk
+            if isequal(a1.kr, b1.kr)
+                c1 = PartitionVacant(a1.kl, a1.kr, a1.left, combine(xform(rf).rf, a1.right, b1.right))
+            else
+                y = complete(xform(rf).rf, a1.right)
+                # @show y
+                a2 = next(inner(rf), a2, y)
+                c1 = PartitionVacant(a1.kl, b1.kr, a1.left, b1.right)
+            end
+        else
+            if isequal(a1.kr, b1.kl)
+                acc = combine(xform(rf).rf, a1.right, b1.left)
+                y = complete(xform(rf).rf, acc)
+                # @show y
+                a2 = next(inner(rf), a2, y)
+                c1 = PartitionVacant(a1.kl, b1.kr, a1.left, b1.right)
+            else
+                ya = complete(xform(rf).rf, a1.right)
+                yb = complete(xform(rf).rf, b1.left)
+                # @show ya yb
+                a2 = next(inner(rf), a2, ya)
+                a2 = next(inner(rf), a2, yb)
+                c1 = PartitionVacant(a1.kl, b1.kr, a1.left, b1.right)
+            end
+        end
+    end
+    # @show c1
+    c2 = combine(inner(rf), a2, b2)
+    return wrap(rf, c1, c2)
+end
+
+left(l, r) = l
+left(l) = l
+InitialValues.@def_monoid left
+
+function array_partitionby(f::F, xs) where {F}
+    @inline getkey(i) = f(@inbounds xs[i])
+    @inline getview((i, j),) = @inbounds view(xs, i:j)
+    return eachindex(xs) |>
+        ReducePartitionBy(getkey, TeeRF((left, right)), DefaultInit) |>
+        Map(getview)
+end
+
+(f::PartitionBy)(xs::AbstractArray) = array_partitionby(f.f, xs)

--- a/src/partitionby.jl
+++ b/src/partitionby.jl
@@ -171,3 +171,7 @@ function array_partitionby(f::F, xs) where {F}
 end
 
 (f::PartitionBy)(xs::AbstractArray) = array_partitionby(f.f, xs)
+
+if VERSION < v"1.3"
+    Base.:|>(xs::AbstractArray, f::PartitionBy) = array_partitionby(f.f, xs)
+end

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -198,7 +198,7 @@ end
     @simd_if rf for i in i0:_lastindex(arr)
         acc = @next(rf, acc, @inbounds arr[i])
     end
-    return complete(rf, acc)
+    return restack(complete(rf, acc))
 end
 
 @inline function _foldl_linear_rec(rf::RF, acc::T, arr, i0, counter) where {RF,T}

--- a/test/preamble.jl
+++ b/test/preamble.jl
@@ -1,3 +1,4 @@
+using BangBang: BangBang, append!!, collector, finish!
 using Test
 using Random
 using SparseArrays: issparse, sparse
@@ -5,7 +6,7 @@ using Statistics: mean
 using Transducers
 using Transducers: Transducer, simple_transduce, Reduced, isexpansive,
     ZipSource, GetIndex, SetIndex, Inject, @~, IdentityTransducer,
-    EmptyResultError, IdentityNotDefinedError, AbortIf, @next
+    EmptyResultError, IdentityNotDefinedError, AbortIf, wheninit, @next
 using Logging: NullLogger, with_logger
 using SplittablesBase: SplittablesBase
 
@@ -146,6 +147,16 @@ function slow_test(f, title, limit)
     end
     return
 end
+
+fcollect(ex::Transducers.Executor) = itr -> fcollect(itr, ex)
+fcollect(itr, ex = PreferParallel()) =
+    finish!(unreduced(transduce(
+        Map(BangBang.SingletonVector),
+        wheninit(collector, append!!),
+        collector(),
+        itr,
+        ex,
+    )))
 
 foldxt_bs1(args...; kw...) = foldxt(args...; basesize = 1, kw...)
 foldxd_bs1(args...; kw...) = foldxd(args...; basesize = 1, kw...)

--- a/test/test_executors.jl
+++ b/test/test_executors.jl
@@ -2,17 +2,6 @@ module TestExecutors
 
 include("preamble.jl")
 import Distributed
-using BangBang: SingletonVector, append!!, collector, finish!
-using Transducers: wheninit
-
-fcollect(itr, ex = PreferParallel()) =
-    finish!(unreduced(transduce(
-        Map(SingletonVector),
-        wheninit(collector, append!!),
-        collector(),
-        itr,
-        ex,
-    )))
 
 @testset "fcollect" begin
     @test fcollect(x for x in 1:10) == 1:10

--- a/test/test_reducepartitionby.jl
+++ b/test/test_reducepartitionby.jl
@@ -1,0 +1,28 @@
+module TestReducePartitionBy
+include("preamble.jl")
+using BangBang: append!!
+using DataTools: inc1
+using MicroCollections: vec0, vec1
+
+@testset for ex in [
+    SequentialEx(),
+    PreferParallel(basesize = 1),
+    PreferParallel(basesize = 2),
+    PreferParallel(basesize = 3),
+    PreferParallel(),
+]
+    count_partitionby(f, xs) = xs |> ReducePartitionBy(f, Completing(inc1)) |> fcollect(ex)
+    collect_partitionby(f, xs) =
+        xs |> ReducePartitionBy(f, Map(vec1)'(Completing(append!!)), vec0()) |> fcollect(ex)
+    view_partitionby(f, xs::AbstractArray) = xs |> PartitionBy(f) |> fcollect(ex)
+
+    @test count_partitionby(x -> x ÷ 3, 1:6) == [2, 3, 1]
+    @test collect_partitionby(x -> x ÷ 3, 1:6) == [1:2, 3:5, 6:6]
+    @test view_partitionby(x -> x ÷ 3, 1:6) == [1:2, 3:5, 6:6]
+end
+
+@testset "array_partitionby" begin
+    @test PartitionBy(identity)(1:3) === Transducers.array_partitionby(identity, 1:3)
+end
+
+end  # module

--- a/test/test_reducepartitionby.jl
+++ b/test/test_reducepartitionby.jl
@@ -23,6 +23,8 @@ end
 
 @testset "array_partitionby" begin
     @test PartitionBy(identity)(1:3) === Transducers.array_partitionby(identity, 1:3)
+    # Test for Julia < 1.3:
+    @test 1:3 |> PartitionBy(identity) === Transducers.array_partitionby(identity, 1:3)
 end
 
 end  # module


### PR DESCRIPTION
## Commit Message
Add ReducePartitionBy (#458)

This patch adds a parallelizable transducer `ReducePartitionBy(f, rf, [init])`
that can be used for fusing intra- and inter-partition reductions. It also
is used for a performance specialization of `array |> PartitionBy(f)` that
does not require allocations of vectors any more.

For example, `ReducePartitionBy` can be used for implementing group reduce
operations that runs in parallel and uses constant space (Note: hash-based
group reduce requires the space at least as large as/proportional to the
number of groups).