### PR TITLE
[NOTE] Effect of restack on ReducePartitionBy performance

### DIFF
--- a/src/processes.jl
+++ b/src/processes.jl
@@ -198,7 +198,7 @@ end
     @simd_if rf for i in i0:_lastindex(arr)
         acc = @next(rf, acc, @inbounds arr[i])
     end
-    return restack(complete(rf, acc))
+    return complete(rf, acc)
 end
 
 @inline function _foldl_linear_rec(rf::RF, acc::T, arr, i0, counter) where {RF,T}


### PR DESCRIPTION
`ReducePartitionBy` added in #458 uses (at least) three distinct types for the nested private state (accumulator). As a result, it was rather tricky to convince the Julia compiler to optimize it.

This is a PR for noting the effect of `restack` at the end of `_foldl_linear_bulk`

https://github.com/JuliaFolds/Transducers.jl/blob/2e58c7706caedabd22c6c84c8cef37e1f1b51180/src/processes.jl#L197-L202

Indeed, with `restack`, we get a large regression:

> | ID                                                  | time ratio                   | memory ratio                 |
> |-----------------------------------------------------|------------------------------|------------------------------|
> | ... | ... | ... |
> | `["partition_length_maximum", "rand", "reduce"]`    |                7.01 (5%) :x: |                   1.00 (1%)  |
>
> -- https://github.com/JuliaFolds/Transducers-data/blob/multi-thread-benchmark-results/2021/03/05/013608/result.md

Note that there is no regression in the sequential (`foldl`) case. This is presumably because we are `complete`'ing at the end of `__foldl__` and so the nested private state are unwrapped to an `Int`. This is not possible in `reduce` since we have to combine the private states across basecases. Maybe `restack`ing the nested private state is useful because it nudges SROA, even though the type inference cannot union-split the nested state.
