### PR TITLE
Add SplitBy

### DIFF
--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -234,11 +234,11 @@ version = "1.0.0"
 
 [[SplittablesBase]]
 deps = ["Setfield", "Test"]
-git-tree-sha1 = "9a5aa2eb673771ced22bba49e8a19c1d41faab1b"
+git-tree-sha1 = "4c902e8d8890d0f772d7a920fd23f81185d3b6de"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaFolds/SplittablesBase.jl.git"
 uuid = "171d559e-b47b-412a-8079-5efa626c420e"
-version = "0.1.9"
+version = "0.1.13-DEV"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/benchmark/multi-thread/bench_splitby.jl
+++ b/benchmark/multi-thread/bench_splitby.jl
@@ -1,0 +1,55 @@
+module BenchSplitBy
+using BenchmarkTools
+using Transducers
+
+const SUITE = BenchmarkGroup()
+
+chunks_longer_than(xs, n) =
+    xs |> SplitBy(iszero; keepend = Val(true)) |> Map(length) |> Filter(>=(n))
+
+count_chunks_longer_than(xs, n, ex) =
+    Transducers.fold(+, chunks_longer_than(xs, n) |> Map(_ -> 1), ex; init = 0)
+
+function man_count_chunks_longer_than(xs, n)
+    c = 0
+    ilast = firstindex(xs) - 1
+    for i in eachindex(xs)
+        x = @inbounds xs[i]
+        if iszero(x)
+            if i - ilast >= n
+                c += 1
+            end
+            ilast = i
+        end
+    end
+    if lastindex(xs) - ilast >= n
+        c += 1
+    end
+    return c
+end
+
+# TODO: find a better way to test benchmark code
+if lowercase(get(ENV, "TRANSDUCERS_JL_TEST_BENCHMARKS", "false")) == "true"
+    using Test
+    using Random: MersenneTwister
+else
+    macro testset(_) end
+end
+
+@testset for seed in 1:20
+    rng = MersenneTwister(seed)
+    xs = rand(rng, 0:9, 2^20)
+    @test man_count_chunks_longer_than(xs, 5) ==
+            count_chunks_longer_than(xs, 5, SequentialEx()) ==
+            count_chunks_longer_than(xs, 5, ThreadedEx())
+end
+
+let s = SUITE["count"] = BenchmarkGroup()
+    xs = rand(0:9, 2^20)
+    s["man"] = @benchmarkable man_count_chunks_longer_than($xs, 5)
+    s["foldl"] = @benchmarkable count_chunks_longer_than($xs, 5, SequentialEx())
+    s["reduce"] = @benchmarkable count_chunks_longer_than($xs, 5, ThreadedEx())
+end
+
+end  # module
+BenchSplitBy.SUITE

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -325,11 +325,11 @@ version = "1.0.0"
 
 [[SplittablesBase]]
 deps = ["Setfield", "Test"]
-git-tree-sha1 = "9a5aa2eb673771ced22bba49e8a19c1d41faab1b"
+git-tree-sha1 = "4c902e8d8890d0f772d7a920fd23f81185d3b6de"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaFolds/SplittablesBase.jl.git"
 uuid = "171d559e-b47b-412a-8079-5efa626c420e"
-version = "0.1.9"
+version = "0.1.13-DEV"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]

--- a/docs/src/reference/manual.md
+++ b/docs/src/reference/manual.md
@@ -91,6 +91,7 @@ PreferParallel
 ## Miscellaneous
 
 ```@docs
+SplitBy
 Transducer(::Transducers.Comprehension)
 Transducer(::OnlineStats.OnlineStat)
 reducingfunction

--- a/src/Transducers.jl
+++ b/src/Transducers.jl
@@ -39,6 +39,7 @@ export AdHocFoldable,
     Scan,
     ScanEmit,
     SequentialEx,
+    SplitBy,
     TCat,
     Take,
     TakeLast,
@@ -148,6 +149,7 @@ include("groupby.jl")
 include("broadcasting.jl")
 include("consecutive.jl")
 include("partitionby.jl")
+include("splitby.jl")
 include("combinators.jl")
 include("simd.jl")
 include("executors.jl")

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -31,6 +31,8 @@ end
 _typeof(::Type{T}) where {T} = Type{T}
 _typeof(::T) where {T} = T
 
+const ValBool = Union{Val{false}, Val{true}}
+
 function _materializer(xs)
     T = Tables.materializer(xs)
     return T isa Type ? T : _materializer(typeof(xs))

--- a/src/lister.jl
+++ b/src/lister.jl
@@ -49,7 +49,10 @@ end
 TransducerLister() = TransducerLister(@__MODULE__)
 
 Transducer(tl::TransducerLister) = opcompose(
-    Filter(x -> is_transducer_type(getproperty(tl.m, x))),
+    Filter() do x
+        t = getproperty(tl.m, x)
+        is_transducer_type(t) && !is_internal(t)
+    end,
     Map(x -> Docs.Binding(tl.m, x)),
 )
 

--- a/src/splitby.jl
+++ b/src/splitby.jl
@@ -194,20 +194,20 @@ julia> using Transducers
 julia> xs = [1, 2, 3, 0, 1, 2, 3, 4, 0, 0, 1, 2];  # input
 
 julia> xs |> SplitBy(iszero) |> Map(collect) |> collect
-3-element Vector{Vector{Int64}}:
+3-element Array{Array{Int64,1},1}:
  [1, 2, 3]
  [1, 2, 3, 4]
  [1, 2]
 
 julia> xs |> SplitBy(iszero; keepempty = true) |> Map(collect) |> collect
-4-element Vector{Vector{Int64}}:
+4-element Array{Array{Int64,1},1}:
  [1, 2, 3]
  [1, 2, 3, 4]
  []
  [1, 2]
 
 julia> xs |> SplitBy(iszero; keepend = true) |> Map(collect) |> collect
-4-element Vector{Vector{Int64}}:
+4-element Array{Array{Int64,1},1}:
  [1, 2, 3, 0]
  [1, 2, 3, 4, 0]
  [0]

--- a/src/splitby.jl
+++ b/src/splitby.jl
@@ -183,7 +183,7 @@ input     keepend=false       keepend=false        keepend=true
 2            | y3                | y4                | y4
 ```
 
-In the above diagram, `yi` (`i = 1, 2, 3, 4`) are the output `SplitBy`. This
+In the above diagram, `yi` (`i = 1, 2, 3, 4`) are the output of `SplitBy`. This
 can be checked in the REPL easily as follows. (Note: we are using
 `Map(collect)` for cleaner printing; it's not required unless the arrays is
 mutated in the downstream.)

--- a/src/splitby.jl
+++ b/src/splitby.jl
@@ -1,0 +1,281 @@
+"""
+    Transducers.ReduceSplitBy(f, rf, init)
+
+Split chunks by elements evaluated to `true` by `f` and reduce each chunk by
+reducing function `rf`.
+
+!!! note
+    This is an internal implementation detail of [`SplitBy`](@ref) for now.
+
+The reducing function `rf` receives either a `Bulk(x)` if `!f(x)` or a
+`End(x)` if `f(x)` returns `true`. Just just after `rf` is called with
+`End(x)`, its accumulator is finalized by [`complete`](@ref) and then passed
+to the downstream transducer/reducing function.
+
+# Examples
+```jldoctest
+julia> using Transducers
+       using Transducers: ReduceSplitBy, Bulk, End
+
+julia> 1:5 |> ReduceSplitBy(isodd, Map(getindex)'(string), "") |> collect
+3-element Array{String,1}:
+ "1"
+ "23"
+ "45"
+
+julia> function just_bulk(x)
+           if x isa Bulk
+               Some(x[])
+           else
+               nothing
+           end
+       end;
+
+julia> 1:5 |> ReduceSplitBy(isodd, KeepSomething(just_bulk)'(string), "") |> collect
+3-element Array{String,1}:
+ ""
+ "2"
+ "4"
+```
+"""
+struct ReduceSplitBy{F,RF,Init} <: Transducer
+    f::F
+    rf::RF
+    init::Init
+end
+
+abstract type _Element end
+Base.getindex(x::_Element) = x.value
+
+struct Bulk{T} <: _Element
+    value::T
+end
+
+struct End{T} <: _Element
+    value::T
+end
+
+struct Chunk{Right}
+    right::Right
+end
+is_prelude(::Chunk) = true
+
+struct Vacant{Left,Right}
+    left::Left
+    right::Right
+end
+
+start(rf::R_{ReduceSplitBy}, acc) = wrap(rf, Chunk(nothing), start(inner(rf), acc))
+
+next(rf::R_{ReduceSplitBy}, acc, input) =
+    wrapping(rf, acc) do state, iacc
+        if state.right === nothing
+            acc0 = start(xform(rf).rf, xform(rf).init)
+        else
+            acc0 = something(state.right)
+        end
+        if xform(rf).f(input)
+            acc1 = next(xform(rf).rf, acc0, End(input))
+            # @show acc1
+            if state isa Vacant
+                y = complete(xform(rf).rf, acc1)
+                iacc′ = next(inner(rf), iacc, y)
+                left = state.left
+            else
+                iacc′ = iacc
+                left = acc1
+            end
+            (Vacant(left, nothing), iacc′)
+        else
+            right = Some(next(xform(rf).rf, acc0, Bulk(input)))
+            ((@set state.right = right), iacc)
+        end
+    end
+
+function complete(rf::R_{ReduceSplitBy}, acc)
+    state, iacc1 = unwrap(rf, acc)
+    if state.right === nothing
+        iacc2 = iacc1
+    else
+        yr = complete(xform(rf).rf, something(state.right))
+        iacc2 = next(inner(rf), iacc1, yr)
+    end
+    if state isa Vacant
+        # @show state.left
+        yl = complete(inner(rf), state.left)
+        # TODO: Is it OK to always use DefaultInit? Is there a better way?
+        iacc0 = next(inner(rf), start(inner(rf), DefaultInit), yl)
+        iacc3 = combine(inner(rf), iacc0, iacc2)
+    else
+        iacc3 = iacc2
+    end
+    return complete(inner(rf), iacc3)
+end
+
+@inline maybe_combine(_, ::Nothing, ::Nothing) = nothing
+@inline maybe_combine(_, x::Some, ::Nothing) = x
+@inline maybe_combine(_, ::Nothing, x::Some) = x
+@inline maybe_combine(rf::RF, a::Some, b::Some) where {RF} =
+    Some(combine(rf, something(a), something(b)))
+
+function combine(rf::R_{ReduceSplitBy}, a, b)
+    a1, a2 = unwrap(rf, a)
+    b1, b2 = unwrap(rf, b)
+    if a1 isa Chunk
+        if b1 isa Chunk
+            c1 = Chunk(maybe_combine(xform(rf).rf, a1.right, b1.right))
+        else
+            left = something(maybe_combine(xform(rf).rf, a1.right, Some(b1.left)))
+            c1 = Vacant(left, b1.right)
+        end
+    else
+        if b1 isa Chunk
+            c1 = Vacant(a1.left, maybe_combine(xform(rf).rf, a1.right, b1.right))
+        else
+            acc = something(maybe_combine(xform(rf).rf, a1.right, Some(b1.left)))
+            y = complete(xform(rf).rf, acc)
+            a2 = next(inner(rf), a2, y)
+            c1 = Vacant(a1.left, b1.right)
+        end
+    end
+    c2 = combine(inner(rf), a2, b2)
+    return wrap(rf, c1, c2)
+end
+
+"""
+    SplitBy(f; [keepend = false,] [keepempty = false,])
+
+Split input collection into chunks delimited by the elements on which `f`
+returns `true`. This can be used to implement parallel and lazy versions of
+functions like `eachline` and `split`.
+
+If `keepend` is `true` (or `Val(true)`), include the "delimiter"/end element
+at the end of each chunk. If `keepempty` is `true` (or `Val(true)`), include
+empty chunks. When `keepend` is `true`, the value of `keepempty` is
+irrelevant since the chunks cannot be empty (i.e., it at least contains the
+end).
+
+The input collection (`xs` in `SplitBy(...)(xs)`) has to support `eachindex`
+and `view` or `SubString`.
+
+# Extended Help
+
+## Examples
+
+For demonstration, consider the following input stream and `SplitBy(iszero;
+...)` used with the following options:
+
+```
+input     keepend=false       keepend=false        keepend=true
+          keepempty=false     keepempty=true
+
+1           `.                  `.                  `.
+2            | y1                | y1                | y1
+3           ,'                  ,'                   |
+0                                                   ,'
+1           `.                  `.                  `.
+2            | y2                | y2                | y2
+3            |                   |                   |
+4           ,'                  ,'                   |
+0                               __ y3               ,'
+0                                                    ] y3
+1           `.                  `.                  `.
+2            | y3                | y4                | y4
+```
+
+In the above diagram, `yi` (`i = 1, 2, 3, 4`) are the output `SplitBy`. This
+can be checked in the REPL easily as follows. (Note: we are using
+`Map(collect)` for cleaner printing; it's not required unless the arrays is
+mutated in the downstream.)
+
+```jldoctest
+julia> using Transducers
+
+julia> xs = [1, 2, 3, 0, 1, 2, 3, 4, 0, 0, 1, 2];  # input
+
+julia> xs |> SplitBy(iszero) |> Map(collect) |> collect
+3-element Vector{Vector{Int64}}:
+ [1, 2, 3]
+ [1, 2, 3, 4]
+ [1, 2]
+
+julia> xs |> SplitBy(iszero; keepempty = true) |> Map(collect) |> collect
+4-element Vector{Vector{Int64}}:
+ [1, 2, 3]
+ [1, 2, 3, 4]
+ []
+ [1, 2]
+
+julia> xs |> SplitBy(iszero; keepend = true) |> Map(collect) |> collect
+4-element Vector{Vector{Int64}}:
+ [1, 2, 3, 0]
+ [1, 2, 3, 4, 0]
+ [0]
+ [1, 2]
+```
+"""
+struct SplitBy{F,KeepEnd<:ValBool,KeepEmpty<:ValBool} # <: Transducer  # TODO: should I?
+    f::F
+    keepend::KeepEnd
+    keepempty::KeepEmpty
+end
+
+SplitBy(
+    f;
+    keepend::Union{Bool,ValBool} = Val(false),
+    keepempty::Union{Bool,ValBool} = Val(false),
+) = SplitBy(f, asval(keepend), asval(keepempty))
+
+struct SplitByReducingFunction{KeepEnd<:ValBool,KeepEmpty<:ValBool}
+    keepend::KeepEnd
+    keepempty::KeepEmpty
+end
+
+function next(rf::SplitByReducingFunction, a, b)
+    # @show a b
+    j = b[]
+    if a === nothing
+        i = j
+        k = j - 1
+    else
+        i, k, = a::Tuple{Any,Any}
+    end
+    if b isa Bulk
+        return (i, j)
+    else
+        b::End
+        if rf.keepend === Val(true)
+            return (i, j)
+        elseif rf.keepempty === Val(true)
+            return (i, k)
+        elseif a === nothing
+            return nothing
+        else
+            return (i, k)
+        end
+    end
+end
+
+function combine(::SplitByReducingFunction, a, b)
+    a === nothing && return b
+    b === nothing && return a
+    return (a[1], b[2])
+end
+
+complete(::SplitByReducingFunction, a) = a
+
+(f::SplitBy)(xs) =
+    xs |>
+    eachindex |>
+    ReduceSplitBy(
+        i -> f.f(@inbounds xs[i]),
+        SplitByReducingFunction(f.keepend, f.keepempty),
+        nothing,
+    ) |>
+    NotA(Nothing) |>
+    Map(sb_viewer(xs))
+# TODO: Check if it is better to use `pairs`; note that it'd require
+# `pairs(::AbstractString)` to return some structured iterator.
+
+sb_viewer(xs) = view_any((i, j),) = view(xs, i:j)
+sb_viewer(xs::AbstractString) = view_str((i, j),) = SubString(xs, i, j)

--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -367,11 +367,11 @@ version = "1.0.0"
 
 [[SplittablesBase]]
 deps = ["Setfield", "Test"]
-git-tree-sha1 = "9a5aa2eb673771ced22bba49e8a19c1d41faab1b"
+git-tree-sha1 = "4c902e8d8890d0f772d7a920fd23f81185d3b6de"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaFolds/SplittablesBase.jl.git"
 uuid = "171d559e-b47b-412a-8079-5efa626c420e"
-version = "0.1.9"
+version = "0.1.13-DEV"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -369,11 +369,11 @@ version = "1.0.0"
 
 [[SplittablesBase]]
 deps = ["Setfield", "Test"]
-git-tree-sha1 = "9a5aa2eb673771ced22bba49e8a19c1d41faab1b"
+git-tree-sha1 = "4c902e8d8890d0f772d7a920fd23f81185d3b6de"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaFolds/SplittablesBase.jl.git"
 uuid = "171d559e-b47b-412a-8079-5efa626c420e"
-version = "0.1.9"
+version = "0.1.13-DEV"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]

--- a/test/test_splitby.jl
+++ b/test/test_splitby.jl
@@ -1,0 +1,64 @@
+module TestSplitBy
+include("preamble.jl")
+using Transducers: ReduceSplitBy, Bulk, End
+
+function just_bulk(x)
+    if x isa Bulk
+        Some(x[])
+    else
+        x::End
+        nothing
+    end
+end
+
+@testset "ReduceSplitBy" begin
+    @test 1:5 |> ReduceSplitBy(iseven, Map(getindex)'(string), "_") |> collect ==
+          ["_12", "_34", "_5"]
+    @test 1:5 |> ReduceSplitBy(isodd, Map(getindex)'(string), "_") |> collect ==
+          ["_1", "_23", "_45"]
+    @test 1:5 |> ReduceSplitBy(iseven, KeepSomething(just_bulk)'(string), "_") |> collect ==
+          ["_1", "_3", "_5"]
+    @test 1:5 |> ReduceSplitBy(isodd, KeepSomething(just_bulk)'(string), "_") |> collect ==
+          ["_", "_2", "_4"]
+end
+
+@testset for ex in [
+    SequentialEx(),
+    PreferParallel(basesize = 1),
+    PreferParallel(basesize = 2),
+    PreferParallel(basesize = 3),
+    PreferParallel(),
+]
+    @test 1:5 |> ReduceSplitBy(iseven, Map(getindex)'(string), "") |> fcollect(ex) ==
+          ["12", "34", "5"]
+    @test 1:5 |> ReduceSplitBy(isodd, Map(getindex)'(string), "") |> fcollect(ex) ==
+          ["1", "23", "45"]
+    @test 1:5 |> ReduceSplitBy(iseven, KeepSomething(just_bulk)'(string), "") |> fcollect(ex) ==
+          ["1", "3", "5"]
+    @test 1:5 |> ReduceSplitBy(isodd, KeepSomething(just_bulk)'(string), "") |> fcollect(ex) ==
+          ["", "2", "4"]
+
+    @test 1:5 |> SplitBy(==(4)) |> fcollect(ex) == [1:3, 5:5]
+    @test 1:5 |> SplitBy(==(5)) |> fcollect(ex) == [1:4]
+    @test 1:5 |> SplitBy(==(4); keepend = true) |> fcollect(ex) == [1:4, 5:5]
+    @test 1:5 |> SplitBy(==(5); keepend = true) |> fcollect(ex) == [1:5]
+    @test 1:5 |> SplitBy(==(4); keepempty = true) |> fcollect(ex) == [1:3, 5:5]
+    @test 1:5 |> SplitBy(==(5); keepempty = true) |> fcollect(ex) == [1:4]
+
+    @test 1:5 |> SplitBy(>=(4)) |> fcollect(ex) == [1:3]
+    @test 1:5 |> SplitBy(>=(4); keepend = true) |> fcollect(ex) == [1:4, 5:5]
+    @test 1:5 |> SplitBy(>=(4); keepempty = true) |> fcollect(ex) == [1:3, 5:4]
+
+    @test 1:5 |> SplitBy(isodd) |> fcollect(ex) == [2:2, 4:4]
+    @test 1:5 |> SplitBy(isodd; keepend = true) |> fcollect(ex) == [1:1, 2:3, 4:5]
+    @test 1:5 |> SplitBy(isodd; keepempty = true) |> fcollect(ex) == [1:0, 2:2, 4:4]
+
+    @test 1:4 |> SplitBy(iseven) |> fcollect(ex) == [1:1, 3:3]
+    @test 1:4 |> SplitBy(iseven; keepend = true) |> fcollect(ex) == [1:2, 3:4]
+    @test 1:4 |> SplitBy(iseven; keepempty = true) |> fcollect(ex) == [1:1, 3:3]
+
+    @test "1 2  3" |> SplitBy(==(' ')) |> fcollect(ex) == ["1", "2", "3"]
+    @test "1 α 3" |> SplitBy(==(' ')) |> fcollect(ex) == ["1", "α", "3"]
+end
+
+end  # module


### PR DESCRIPTION
## Commit Message
Add SplitBy (#461)

This patch adds `SplitBy` iterator transformation and an underlying
(ATM internal) `ReduceSplitBy` transducer. `SplitBy` can be used for
processing like `eachline` and `split` in parallel and/or streaming
programs.