### PR TITLE
Fix stateful transducers with Distributed

### DIFF
--- a/src/dreduce.jl
+++ b/src/dreduce.jl
@@ -96,8 +96,15 @@ function dtransduce(
         )
     end
     # TODO: Cancel remote computation when there is a Reduced.
+
+    # If `rf` contains stateful transducers using anonymous functions, the
+    # states will be detected as incompatible for wrap/unwrap. Work around this
+    # issue by using the `rf` object that is used on the remotes.
+    frfr = Distributed.remotecall(identity, pool, rf)
+
     results = map(fetch, futures)
-    return complete(rf, combine_all(rf, results))
+    rfr = fetch(frfr)
+    return complete(rfr, combine_all(rfr, results))
 end
 
 function load_me_everywhere()

--- a/test/threads/test_fold.jl
+++ b/test/threads/test_fold.jl
@@ -106,6 +106,12 @@ end
     @test transduce(Map(-), max, Init(max), [5, 2, 6, 8, 3], ex()) === -2
     @test fold(min, [5, 2, 6, 8, 3], ex()) === 2
     @test fold(TeeRF(min, max), [5, 2, 6, 8, 3], ex()) === (2, 8)
+    @testset "PartitionBy" begin
+        # Testing that DistributedEx can handle a stateful transducer based on
+        # an anonymous functions defined in Main:
+        itr = @eval Main 1:10 |> PartitionBy(x -> x ÷ 3) |> Map(string)
+        @test itr |> fcollect(ex()) == ["1:2", "3:5", "6:8", "9:10"]
+    end
 end
 
 @testset "default executor" begin

--- a/test/threads/test_fold.jl
+++ b/test/threads/test_fold.jl
@@ -109,8 +109,8 @@ end
     @testset "PartitionBy" begin
         # Testing that DistributedEx can handle a stateful transducer based on
         # an anonymous functions defined in Main:
-        itr = @eval Main 1:10 |> $PartitionBy(x -> x ÷ 3) |> $Map(string)
-        @test itr |> fcollect(ex()) == ["1:2", "3:5", "6:8", "9:10"]
+        itr = @eval Main 1:10 |> $PartitionBy(x -> x ÷ 3) |> $Map(first)
+        @test itr |> fcollect(ex()) == [1, 3, 6, 9]
     end
 end
 

--- a/test/threads/test_fold.jl
+++ b/test/threads/test_fold.jl
@@ -109,7 +109,7 @@ end
     @testset "PartitionBy" begin
         # Testing that DistributedEx can handle a stateful transducer based on
         # an anonymous functions defined in Main:
-        itr = @eval Main 1:10 |> PartitionBy(x -> x ÷ 3) |> Map(string)
+        itr = @eval Main 1:10 |> $PartitionBy(x -> x ÷ 3) |> $Map(string)
         @test itr |> fcollect(ex()) == ["1:2", "3:5", "6:8", "9:10"]
     end
 end


### PR DESCRIPTION
## Commit Message
Fix stateful transducers with Distributed (#466)

If a stateful transducer uses any anonymous functions defined in
`Main`, the states will be detected as incompatible by `unwrap` when
`dtransduce` tries to combine private states constructed
remotely. This patch works around this issue by using the reducing
function `rf` object that is used on the remotes.