### PR TITLE
Make transducer listing work again

### DIFF
--- a/src/lister.jl
+++ b/src/lister.jl
@@ -51,7 +51,7 @@ TransducerLister() = TransducerLister(@__MODULE__)
 Transducer(tl::TransducerLister) = opcompose(
     Filter() do x
         t = getproperty(tl.m, x)
-        is_transducer_type(t) && !is_internal(t)
+        is_transducer_type(t)
     end,
     Map(x -> Docs.Binding(tl.m, x)),
 )


### PR DESCRIPTION
fix #465

## Commit Message
Make transducer listing work again (#469)

It looks like the filtering condition introduced in #461 for hiding
`ReduceSplitBy` (IIRC) was unnecessary and is actually hiding
everything.
