### PR TITLE
Don't call completebasecase in foldl_nocomplete

### DIFF
--- a/src/processes.jl
+++ b/src/processes.jl
@@ -349,14 +349,21 @@ function simple_transduce(xform, f, init, coll)
 end
 
 """
-    foldl_basecase(rf, init, coll)
+    foldl_nocomplete(rf, init, coll)
 
 Call [`__foldl__`](@ref) without calling [`complete`](@ref).
 """
+@inline foldl_nocomplete(rf::RF, init, coll) where {RF} =
+    __foldl__(skipcomplete(rf), init, coll)
+
+"""
+    foldl_basecase(rf, init, coll)
+
+`foldl` for basecase of parallel reduction.  Call [`__foldl__`](@ref) without
+calling [`complete`](@ref) and then call `completebasecase`.
+"""
 @inline foldl_basecase(rf::RF, init, coll) where {RF} =
     completebasecase(rf, __foldl__(skipcomplete(rf), init, coll))
-
-const foldl_nocomplete = foldl_basecase
 
 """
     foldxl(step, xf::Transducer, reducible; init, simd) :: T


### PR DESCRIPTION
`completebasecase` should not be called in, e.g., `Cat`