### PR TITLE
Fix `Partition()` w/ `size` greater than the length of the input

### DIFF
--- a/src/library.jl
+++ b/src/library.jl
@@ -904,8 +904,12 @@ end
 function complete(rf::R_{Partition}, result)
     (i, s, buf), iresult = unwrap(rf, result)
     if xform(rf).flush && s != xform(rf).step
-        iinput = @view buf[i:i + xform(rf).size - 1] # unsafe_view? @inbounds?
-        iinput = @view iinput[s + 1:end]
+        if s != 0
+            iinput = @view buf[i:i + xform(rf).size - 1] # unsafe_view? @inbounds?
+            iinput = @view iinput[s + 1:end]
+        else
+            iinput = @view buf[1:end]
+        end
         iinput :: DenseSubVector
         iresult = @next(inner(rf), iresult, iinput)
     end

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -397,6 +397,16 @@ end
                 [[1:4;], [5:8;], [9:i;]]
         end
     end
+    for w in 1:4
+        for s in [w,1]
+            @testset "w=$w, 1:$i" for i in 1:w
+                @testset for xs in iterator_variants(1:i)
+                    @test xs |> Partition(w, s, flush=false) |> Map(copy) |> collect == (w == i ? [[1:i;]] : [])
+                    @test xs |> Partition(w, s, flush=true) |> Map(copy) |> collect == [[1:i;]]
+                end
+            end
+        end
+    end
     @testset "Combination with stateful transducers" begin
         @testset for xs in iterator_variants(1:6)
             @test xs |> Take(5) |> Partition(3, 1) |> Map(copy) |> collect ==


### PR DESCRIPTION
`complete()` only worked correctly if at least a single full partition
has been produced already, otherwise the `buf` would be smaller
than the `xform(rf).size`, and we get buffer overflow, etc.

I've added sufficient test coverage for the issue, that now passes.

I have stumbled into this while trying to write a reduction tree,
not sure if this is something that might be interesting here?

Fixes https://github.com/JuliaFolds/Transducers.jl/issues/528