### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/partitionby.jl
+++ b/src/partitionby.jl
@@ -47,7 +47,7 @@ struct ReducePartitionBy{F,RF,Init} <: Transducer
 end
 ReducePartitionBy(f, rf) = ReducePartitionBy(f, rf, Init)
 
-Adapt.adapt_structure(to, xf::ReducePartitionBy) where {inbounds} = ReducePartitionBy(
+Adapt.adapt_structure(to, xf::ReducePartitionBy) = ReducePartitionBy(
     Adapt.adapt(to, xf.f),
     Adapt.adapt(to, xf.rf),
     Adapt.adapt(to, xf.init),

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -219,7 +219,7 @@ end
     return complete(rf, acc)
 end
 
-@inline function _foldl_array(rf0::RF, init, arr, ::IndexStyle) where {RF,T}
+@inline function _foldl_array(rf0::RF, init, arr, ::IndexStyle) where {RF}
     @inline getvalue(I) = @inbounds arr[I]
     rf = Map(getvalue)'(rf0)
     return __foldl__(rf, init, _CartesianIndices(arr))


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.